### PR TITLE
fix(rankings): avoid sorting undefined; fetch top averages from API w…

### DIFF
--- a/src/pages/Rankings.jsx
+++ b/src/pages/Rankings.jsx
@@ -1,11 +1,94 @@
-import Table from '../components/Table.jsx'
-import { useStore } from '../store/useStore'
-
+import { useEffect, useState } from 'react';
+import Table from '../components/Table.jsx';
+import { api } from '../lib/api';
 
 export default function Rankings() {
-    const bowlers = useStore(s => s.bowlers)
-    const rows = bowlers.sort((a, b) => b.avg - a.avg).map((b, i) => ({ rank: i + 1, name: b.name, avg: b.avg }))
+    const [rows, setRows] = useState([]);
+    const [minGames, setMinGames] = useState(3);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        let ok = true;
+
+        (async () => {
+            setLoading(true);
+            setError('');
+            try {
+                // Server returns overall rankings across all bowlers
+                // (endpoint was added earlier: GET /rankings/top-averages?limit=50)
+                const data = await api.get('/rankings/top-averages?limit=50');
+
+                const normalized = (Array.isArray(data) ? data : []).map((r, i) => ({
+                    // normalize unknown shapes coming from SQL
+                    name:
+                        r.name ??
+                        r.bowler_name ??
+                        r.bowler?.name ??
+                        'Unknown',
+                    games: r.games ?? r.games_played ?? r.count ?? 0,
+                    average: Math.round(r.average ?? r.avg ?? 0),
+                    high: r.high ?? r.high_game ?? r.max ?? 0,
+                }));
+
+                // filter + sort defensively
+                const filtered = normalized
+                    .filter((r) => (r.games ?? 0) >= minGames)
+                    .sort((a, b) => (b.average ?? 0) - (a.average ?? 0))
+                    .map((r, idx) => ({ rank: idx + 1, ...r }));
+
+                if (ok) setRows(filtered);
+            } catch (e) {
+                if (ok) setError(e.message || 'Failed to load rankings');
+            } finally {
+                if (ok) setLoading(false);
+            }
+        })();
+
+        return () => {
+            ok = false;
+        };
+    }, [minGames]);
+
+    const columns = [
+        { key: 'rank', header: '#' },
+        { key: 'name', header: 'Bowler' },
+        { key: 'games', header: 'Games' },
+        { key: 'average', header: 'Average' },
+        { key: 'high', header: 'High' },
+    ];
+
     return (
-        <Table columns={[{ key: 'rank', header: '#' }, { key: 'name', header: 'Bowler' }, { key: 'avg', header: 'Average' }]} rows={rows} />
-    )
+        <div className="grid gap-4">
+            <div className="panel flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <h2 className="text-lg font-semibold">Top Averages</h2>
+                <label className="flex items-center gap-2">
+                    <span className="label">Min games</span>
+                    <input
+                        type="number"
+                        min={1}
+                        className="input w-24"
+                        value={minGames}
+                        onChange={(e) => setMinGames(Number(e.target.value) || 1)}
+                    />
+                </label>
+            </div>
+
+            {error && (
+                <div className="panel text-red-400 text-sm">
+                    {error}
+                </div>
+            )}
+
+            {loading ? (
+                <div className="panel text-slate-300">Loading rankings…</div>
+            ) : rows.length === 0 ? (
+                <div className="panel text-slate-300">
+                    No ranking data yet. Once bowlers record scores, you’ll see the leaderboard here.
+                </div>
+            ) : (
+                <Table columns={columns} rows={rows} />
+            )}
+        </div>
+    );
 }


### PR DESCRIPTION
### Summary
Fix crash on Rankings page caused by sorting undefined demo data.
Now fetches rankings from the API (`/rankings/top-averages`) and
adds loading/empty/error states.

### Changes
- Rankings.jsx: fetch from API, normalize payload, defensive filtering/sorting
- UI: min-games control, friendly empty + loading states

### How to test
1) Start API + web: `npm run dev:all`
2) Visit /rankings
   - While loading: “Loading rankings…”
   - With no data: empty-state message
   - With data: table sorted by average desc
3) Change “Min games” input → list updates accordingly
4) Network failure → error panel shown

### Risk
Low. Scope limited to Rankings page; doesn’t change data model or routes.

